### PR TITLE
Fix build: add vitest/config type reference

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,3 +1,4 @@
+/// <reference types="vitest/config" />
 import { defineConfig } from 'vite'
 import react from '@vitejs/plugin-react'
 


### PR DESCRIPTION
One-line fix for the CI build failure after merging #17.

```
error TS2769: 'test' does not exist in type 'UserConfigExport'
```

Adding `/// <reference types="vitest/config" />` tells TypeScript about Vitest's test config property on Vite's config type.