### PR TITLE
Fix black screen on book club pages

### DIFF
--- a/src/pages/GroupItemDetailPage.tsx
+++ b/src/pages/GroupItemDetailPage.tsx
@@ -366,7 +366,19 @@ export function GroupItemDetailPage({ apiUrl }: GroupItemDetailPageProps) {
 
       if (progressRes.ok) {
         const progressData = await progressRes.json();
-        setProgressMap(progressData.progressBySegment || {});
+        const raw = progressData.progressBySegment || {};
+        // API returns single records (object|null); normalize to arrays
+        const normalized: Record<string, SegmentProgress[]> = {};
+        for (const [segUri, prog] of Object.entries(raw)) {
+          if (Array.isArray(prog)) {
+            normalized[segUri] = prog;
+          } else if (prog) {
+            normalized[segUri] = [prog as SegmentProgress];
+          } else {
+            normalized[segUri] = [];
+          }
+        }
+        setProgressMap(normalized);
       }
     } catch (err: unknown) {
       setError(err instanceof Error ? err.message : 'An error occurred');

--- a/src/test/CreateEventModal.test.tsx
+++ b/src/test/CreateEventModal.test.tsx
@@ -85,8 +85,6 @@ describe('CreateEventModal', () => {
     // The button is disabled if name is empty, so we test via form submit mechanics:
     // Fill name, fill start time, clear name, submit
     const nameInput = screen.getByPlaceholderText(/may book club meetup/i);
-    const startsAtInput = screen.getByDisplayValue('') as HTMLInputElement;
-
     await userEvent.type(nameInput, 'temp');
     // Find datetime-local input
     const datetimeInput = document.querySelector('input[type="datetime-local"]') as HTMLInputElement;
@@ -146,7 +144,7 @@ describe('CreateEventModal', () => {
       json: async () => ({ event: { rkey: 'new-evt', name: 'Phase 2 Party' } }),
     } as Response);
 
-    const { onCreated } = renderModal();
+    renderModal();
 
     const nameInput = screen.getByPlaceholderText(/may book club meetup/i);
     await userEvent.type(nameInput, 'Phase 2 Party');

--- a/src/test/EventCard.test.tsx
+++ b/src/test/EventCard.test.tsx
@@ -40,7 +40,7 @@ const mockOngoingEvent = {
   status: 'ongoing' as const,
 };
 
-function renderCard(event: typeof mockEvent) {
+function renderCard(event: typeof mockEvent | typeof mockOngoingEvent) {
   return render(
     <Provider>
       <MemoryRouter>


### PR DESCRIPTION
## Problem
Book club pages crash with a black screen when any user has marked progress on a reading segment.

## Root Cause
The progress API endpoint returns single objects per segment (`{uri, rkey, completed, ...}` or `null`), but the frontend expects arrays (`SegmentProgress[]`). When a user has progress, `progressMap[seg.uri]` is a plain object, and calling `.filter()` or `.some()` on it throws a TypeError. With no error boundary, React unmounts the entire tree → black screen.

## Fix
Normalize the API response: wrap single objects in arrays and convert nulls to empty arrays before setting state. This handles both the current single-record format and a future array format gracefully.