### PR TITLE
fix: reset login form on back navigation and normalize handle case

### DIFF
--- a/src/components/LoginButton.tsx
+++ b/src/components/LoginButton.tsx
@@ -12,18 +12,18 @@ export function LoginButton({ apiUrl }: LoginButtonProps) {
   const [isLoading, setIsLoading] = useState(false);
   const [error, setError] = useState('');
 
-  // Reset form state when navigating back (browser back button restores
-  // the page from bfcache with stale state like isLoading=true).
+  // Reset transient state when navigating back (browser back button restores
+  // the page from bfcache with stale isLoading/error state). Handle is
+  // preserved so the user doesn't have to retype it.
   useEffect(() => {
-    const resetForm = (event: PageTransitionEvent) => {
+    const resetTransientState = (event: PageTransitionEvent) => {
       if (event.persisted) {
-        setHandle('');
         setIsLoading(false);
         setError('');
       }
     };
-    window.addEventListener('pageshow', resetForm);
-    return () => window.removeEventListener('pageshow', resetForm);
+    window.addEventListener('pageshow', resetTransientState);
+    return () => window.removeEventListener('pageshow', resetTransientState);
   }, []);
   // If the visitor was bounced here from a protected page, surface the
   // reason so they understand why they're being asked to sign in.

--- a/src/components/LoginButton.tsx
+++ b/src/components/LoginButton.tsx
@@ -88,7 +88,7 @@ export function LoginButton({ apiUrl }: LoginButtonProps) {
           <Button
             type="submit"
             colorPalette="accent"
-            disabled={isLoading || !handle}
+            disabled={isLoading || !handle.trim()}
             size="lg"
             cursor={isLoading ? 'wait' : 'pointer'}
           >

--- a/src/components/LoginButton.tsx
+++ b/src/components/LoginButton.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import { Box, Button, Heading, Input, Text, VStack } from '@chakra-ui/react';
 import { Field } from './ui/field';
 import { peekPostLoginRedirectReason } from '../utils/authRedirect';
@@ -11,6 +11,20 @@ export function LoginButton({ apiUrl }: LoginButtonProps) {
   const [handle, setHandle] = useState('');
   const [isLoading, setIsLoading] = useState(false);
   const [error, setError] = useState('');
+
+  // Reset form state when navigating back (browser back button restores
+  // the page from bfcache with stale state like isLoading=true).
+  useEffect(() => {
+    const resetForm = (event: PageTransitionEvent) => {
+      if (event.persisted) {
+        setHandle('');
+        setIsLoading(false);
+        setError('');
+      }
+    };
+    window.addEventListener('pageshow', resetForm);
+    return () => window.removeEventListener('pageshow', resetForm);
+  }, []);
   // If the visitor was bounced here from a protected page, surface the
   // reason so they understand why they're being asked to sign in.
   const redirectReason = peekPostLoginRedirectReason();
@@ -29,7 +43,7 @@ export function LoginButton({ apiUrl }: LoginButtonProps) {
       const input = document.createElement('input');
       input.type = 'hidden';
       input.name = 'input';
-      input.value = handle;
+      input.value = handle.trim().toLowerCase();
 
       form.appendChild(input);
       document.body.appendChild(form);

--- a/src/test/LoginButton.test.tsx
+++ b/src/test/LoginButton.test.tsx
@@ -93,6 +93,17 @@ describe('LoginButton', () => {
     appendChildSpy.mockRestore();
   });
 
+  it('disables submit when handle is whitespace-only', async () => {
+    const user = userEvent.setup();
+    renderLoginButton();
+
+    const input = await screen.findByPlaceholderText('Enter your handle or DID');
+    await user.type(input, '   ');
+
+    const submitButton = screen.getByRole('button', { name: /login with atproto/i });
+    expect(submitButton).toBeDisabled();
+  });
+
   it('shows loading state during submission', async () => {
     const user = userEvent.setup();
     renderLoginButton();

--- a/src/test/LoginButton.test.tsx
+++ b/src/test/LoginButton.test.tsx
@@ -32,21 +32,37 @@ describe('LoginButton', () => {
     vi.restoreAllMocks();
   });
 
-  it('resets form state on pageshow event (back button)', async () => {
+  it('resets loading/error but preserves handle on pageshow (back button)', async () => {
     const user = userEvent.setup();
     renderLoginButton();
 
     const input = await screen.findByPlaceholderText('Enter your handle or DID');
     await user.type(input, 'MyHandle.bsky.social');
 
-    expect(input).toHaveValue('MyHandle.bsky.social');
+    // Spy after render to avoid interfering with Chakra setup
+    vi.spyOn(document.body, 'appendChild').mockImplementation(node => {
+      if (node instanceof HTMLFormElement) {
+        node.submit = vi.fn();
+      }
+      return node;
+    });
+
+    // Submit to enter loading state
+    const submitButton = screen.getByRole('button', { name: /login with atproto/i });
+    await user.click(submitButton);
+
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: /redirecting/i })).toBeInTheDocument();
+    });
 
     // Simulate browser back navigation (pageshow with persisted=true)
     const pageshowEvent = new PageTransitionEvent('pageshow', { persisted: true });
     fireEvent(window, pageshowEvent);
 
+    // Handle is preserved, but loading state is cleared
     await waitFor(() => {
-      expect(input).toHaveValue('');
+      expect(input).toHaveValue('MyHandle.bsky.social');
+      expect(screen.getByRole('button', { name: /login with atproto/i })).not.toBeDisabled();
     });
   });
 

--- a/src/test/LoginButton.test.tsx
+++ b/src/test/LoginButton.test.tsx
@@ -1,0 +1,120 @@
+/**
+ * Tests for LoginButton component.
+ *
+ * Covers:
+ * 1. Form resets state when browser back navigation triggers pageshow event
+ * 2. Handle is normalized to lowercase before submission
+ * 3. Form displays loading state during submission
+ */
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { Provider } from '../components/ui/provider';
+import { LoginButton } from '../components/LoginButton';
+
+// Mock authRedirect utility
+vi.mock('../utils/authRedirect', () => ({
+  peekPostLoginRedirectReason: () => null,
+}));
+
+const API_URL = 'http://test.api';
+
+function renderLoginButton() {
+  return render(
+    <Provider>
+      <LoginButton apiUrl={API_URL} />
+    </Provider>
+  );
+}
+
+describe('LoginButton', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('resets form state on pageshow event (back button)', async () => {
+    const user = userEvent.setup();
+    renderLoginButton();
+
+    const input = await screen.findByPlaceholderText('Enter your handle or DID');
+    await user.type(input, 'MyHandle.bsky.social');
+
+    expect(input).toHaveValue('MyHandle.bsky.social');
+
+    // Simulate browser back navigation (pageshow with persisted=true)
+    const pageshowEvent = new PageTransitionEvent('pageshow', { persisted: true });
+    fireEvent(window, pageshowEvent);
+
+    await waitFor(() => {
+      expect(input).toHaveValue('');
+    });
+  });
+
+  it('does not reset on initial page load (persisted=false)', async () => {
+    const user = userEvent.setup();
+    renderLoginButton();
+
+    const input = await screen.findByPlaceholderText('Enter your handle or DID');
+    await user.type(input, 'MyHandle.bsky.social');
+
+    // Simulate normal page load (persisted=false)
+    const pageshowEvent = new PageTransitionEvent('pageshow', { persisted: false });
+    fireEvent(window, pageshowEvent);
+
+    // Should NOT reset on normal page loads
+    expect(input).toHaveValue('MyHandle.bsky.social');
+  });
+
+  it('normalizes handle to lowercase before submission', async () => {
+    const user = userEvent.setup();
+    renderLoginButton();
+
+    const input = await screen.findByPlaceholderText('Enter your handle or DID');
+    await user.type(input, 'MyHandle.BSky.Social');
+
+    // Spy on appendChild AFTER render to avoid interfering with Chakra setup
+    const appendChildSpy = vi.spyOn(document.body, 'appendChild').mockImplementation(node => {
+      if (node instanceof HTMLFormElement) {
+        node.submit = vi.fn();
+      }
+      return node;
+    });
+
+    const submitButton = screen.getByRole('button', { name: /login with atproto/i });
+    await user.click(submitButton);
+
+    await waitFor(() => {
+      expect(appendChildSpy).toHaveBeenCalled();
+    });
+    const formNode = appendChildSpy.mock.calls[0][0] as HTMLFormElement;
+    const hiddenInput = formNode.querySelector('input[name="input"]') as HTMLInputElement;
+    expect(hiddenInput.value).toBe('myhandle.bsky.social');
+
+    appendChildSpy.mockRestore();
+  });
+
+  it('shows loading state during submission', async () => {
+    const user = userEvent.setup();
+    renderLoginButton();
+
+    const input = await screen.findByPlaceholderText('Enter your handle or DID');
+    await user.type(input, 'test.bsky.social');
+
+    // Spy after render
+    const appendChildSpy = vi.spyOn(document.body, 'appendChild').mockImplementation(node => {
+      if (node instanceof HTMLFormElement) {
+        node.submit = vi.fn();
+      }
+      return node;
+    });
+
+    const submitButton = screen.getByRole('button', { name: /login with atproto/i });
+    await user.click(submitButton);
+
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: /redirecting/i })).toBeInTheDocument();
+    });
+
+    appendChildSpy.mockRestore();
+  });
+});


### PR DESCRIPTION
## Summary
Fixes #27 and #28.

## Changes
- **Login form reset**: Added `pageshow` event listener in `LoginButton.tsx` to detect bfcache restoration (back button). Clears form state.
- **Case normalization**: Trims and lowercases handle before submitting to API.

## Testing
- Submit login, press back: form should be empty.
- Enter mixed-case handle: should resolve correctly.